### PR TITLE
Added functionality to run crond from an ENV setting

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,12 @@
 FROM alpine:latest
-
 COPY entry.sh /entry.sh
 RUN apk update && \
     apk add bash php php7-apache2 php7-cli php7-common php7-curl php7-gd php7-json php7-mbstring php7-session php7-pdo php7-opcache php7-xml php7-simplexml php7-xmlrpc php7-zip php7-gmp php7-dom php7-gettext openssl apache2 git shadow && \
-    chmod +x /entry.sh && \
+	chmod +x /entry.sh && \
     rm -rf /var/cache/apk/* && \
     mkdir -p /run/apache2 && \
     chown apache: /run/apache2
 EXPOSE 80 443
 ENTRYPOINT ["/entry.sh"]
 CMD ["/usr/sbin/httpd", "-D", "FOREGROUND", "-f", "/etc/apache2/httpd.conf"]
+


### PR DESCRIPTION
Hi, 

I added some functionality to add crontab to the image from an ENV setting. You can specify    `- "SPOTWEB_CRON_RETRIEVE=*/10 * * * *" in your docker-compose file and it will use this line to schedule the retrieve cron job in the image.

Source code was borrowed from https://github.com/jgeusebroek/docker-spotweb but added it to this image, since this one looks a bit neater and is smaller.
`

