### PR TITLE
Fix user for cache check

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -31,7 +31,7 @@ then
 	fi
 	if [[ -n "$SPOTWEB_CRON_CACHE_CHECK" ]]; then
     echo "Creating crontab entry for check-cache with schedule:  $SPOTWEB_CRON_CACHE_CHECK"
-    echo "$SPOTWEB_CRON_CACHE_CHECK /usr/bin/php /var/www/spotweb/bin/check-cache.php >/var/log/stdout 2>&1" >> /etc/crontabs/root
+    echo "$SPOTWEB_CRON_CACHE_CHECK /usr/bin/php /var/www/spotweb/bin/check-cache.php >/var/log/stdout 2>&1" >> /etc/crontabs/apache
 	fi
 fi
 


### PR DESCRIPTION
cache check is not to be run as root user. This will generate an error . Owner of the cache folder must be the user name of the apache instance

https://github.com/spotweb/spotweb/issues/56