### PR TITLE
Create cache dir during instantiation

### DIFF
--- a/entry.sh
+++ b/entry.sh
@@ -22,7 +22,7 @@ fi
 # make sure cache directory exists prior to executing chown -R apache: ${WebDir}
 # if cache dir does not exists, it is created by root user on first retrieve and result in a database error
 
-mkdir cache
+mkdir ${WebDir}/cache
 
 echo
 

--- a/entry.sh
+++ b/entry.sh
@@ -19,6 +19,11 @@ else
   git pull origin master
 fi
 
+# make sure cache directory exists prior to executing chown -R apache: ${WebDir}
+# if cache dir does not exists, it is created by root user on first retrieve and result in a database error
+
+mkdir cache
+
 echo
 
 # Create the Retrieve cron entry


### PR DESCRIPTION
Make sure that cache dir exists when the container is created. If not, spotweb creates the directory as root user and will throws a stats error when retrieving a spot. When cache dir exists, it is automatically chown'ed by entry.sh

![image](https://user-images.githubusercontent.com/1189058/167594718-c506b958-c1a2-4dda-9ac6-ea198433ea74.png)
